### PR TITLE
Add the badges to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+CODECOV_TOKEN="106d1987-6ab3-4019-9c63-56f38aba2e67"
+
 jdk:
   - oraclejdk8
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ jdk:
 #  - openjdk11
 
 script: mvn sonar:sonar -Dsonar.organization=javydreamercsw-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6e3a9d4d7b11e581b919b9ba1498f02ac35a3fa8
+
+script: "mvn cobertura:cobertura"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Tournament Manager
+# Tournament Manager [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=com.github.javydreamercsw:Tournament-Manager&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.github.javydreamercsw:Tournament-Manager) [![Build Status](https://travis-ci.org/javydreamercsw/tournament-manager.svg?branch=master)](https://travis-ci.org/javydreamercsw/tournament-manager) 
+
+<!--[![codecov.io](http://codecov.io/github/mirumee/saleor/coverage.svg?branch=master)](http://codecov.io/github/mirumee/saleor?branch=master)-->
 
 Tools to manage your tournament!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Tournament Manager [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=com.github.javydreamercsw:Tournament-Manager&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.github.javydreamercsw:Tournament-Manager) [![Build Status](https://travis-ci.org/javydreamercsw/tournament-manager.svg?branch=master)](https://travis-ci.org/javydreamercsw/tournament-manager) 
-
-<!--[![codecov.io](http://codecov.io/github/mirumee/saleor/coverage.svg?branch=master)](http://codecov.io/github/mirumee/saleor?branch=master)-->
+# Tournament Manager [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=com.github.javydreamercsw:Tournament-Manager&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.github.javydreamercsw:Tournament-Manager) [![Build Status](https://travis-ci.org/javydreamercsw/tournament-manager.svg?branch=master)](https://travis-ci.org/javydreamercsw/tournament-manager) [![codecov.io](http://codecov.io/gh/javydreamercsw/tournament-manager/coverage.svg?branch=master)](http://codecov.io/gh/javydreamercsw/tournament-manager?branch=master)
 
 Tools to manage your tournament!
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,18 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>xml</format>
+                    </formats>
+                    <check />
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <modules>


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/javydreamercsw/tournament-manager/pull/18%23issuecomment-443387416%22%2C%20%22https%3A//github.com/javydreamercsw/tournament-manager/pull/18%23issuecomment-443387417%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/javydreamercsw/tournament-manager/pull/18%23issuecomment-443387416%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%23%20%5BCodecov%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18%3Fsrc%3Dpr%26el%3Dh1%29%20Report%5Cn%3E%20%3Aexclamation%3A%20No%20coverage%20uploaded%20for%20pull%20request%20base%20%28%60master%40b2f5045%60%29.%20%5BClick%20here%20to%20learn%20what%20that%20means%5D%28https%3A//docs.codecov.io/docs/error-reference%23section-missing-base-commit%29.%5Cn%3E%20The%20diff%20coverage%20is%20%60n/a%60.%5Cn%5Cn%5B%21%5BImpacted%20file%20tree%20graph%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18/graphs/tree.svg%3Fwidth%3D650%26token%3DUCTMA0dVQc%26height%3D150%26src%3Dpr%29%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18%3Fsrc%3Dpr%26el%3Dtree%29%5Cn%5Cn%60%60%60diff%5Cn%40%40%20%20%20%20%20%20%20%20%20%20%20%20Coverage%20Diff%20%20%20%20%20%20%20%20%20%20%20%20%40%40%5Cn%23%23%20%20%20%20%20%20%20%20%20%20%20%20%20master%20%20%20%20%20%20%2318%20%20%20%2B/-%20%20%20%23%23%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Coverage%20%20%20%20%20%20%20%20%20%20%3F%20%20%2031.54%25%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Files%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%20%20%2082%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Lines%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%204413%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Branches%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%20%20674%20%20%20%20%20%20%20%20%20%20%20%5Cn%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5Cn%20%20Hits%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%201392%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Misses%20%20%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%202795%20%20%20%20%20%20%20%20%20%20%20%5Cn%20%20Partials%20%20%20%20%20%20%20%20%20%20%3F%20%20%20%20%20%20226%5Cn%60%60%60%5Cn%5Cn%5Cn%5Cn------%5Cn%5Cn%5BContinue%20to%20review%20full%20report%20at%20Codecov%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18%3Fsrc%3Dpr%26el%3Dcontinue%29.%5Cn%3E%20%2A%2ALegend%2A%2A%20-%20%5BClick%20here%20to%20learn%20more%5D%28https%3A//docs.codecov.io/docs/codecov-delta%29%5Cn%3E%20%60%5Cu0394%20%3D%20absolute%20%3Crelative%3E%20%28impact%29%60%2C%20%60%5Cu00f8%20%3D%20not%20affected%60%2C%20%60%3F%20%3D%20missing%20data%60%5Cn%3E%20Powered%20by%20%5BCodecov%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18%3Fsrc%3Dpr%26el%3Dfooter%29.%20Last%20update%20%5Bb2f5045...3fea39f%5D%28https%3A//codecov.io/gh/javydreamercsw/tournament-manager/pull/18%3Fsrc%3Dpr%26el%3Dlastupdated%29.%20Read%20the%20%5Bcomment%20docs%5D%28https%3A//docs.codecov.io/docs/pull-request-comments%29.%5Cn%22%2C%20%22created_at%22%3A%20%222018-12-01T01%3A29%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/in/254%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/apps/codecov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222018-12-01T01%3A29%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2817343%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/javydreamercsw%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/javydreamercsw%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/2817343%3Fv%3D4%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/javydreamercsw'><img src='https://avatars3.githubusercontent.com/u/2817343?v=4' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/javydreamercsw/tournament-manager/pull/18#issuecomment-443387416'>General Comment</a></b>
- <a href='https://github.com/apps/codecov'><img border=0 src='https://avatars2.githubusercontent.com/in/254?v=4' height=16 width=16></a> # [Codecov](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18?src=pr&el=h1) Report
> :exclamation: No coverage uploaded for pull request base (`master@b2f5045`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference#section-missing-base-commit).
> The diff coverage is `n/a`.
[![Impacted file tree graph](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18/graphs/tree.svg?width=650&token=UCTMA0dVQc&height=150&src=pr)](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18?src=pr&el=tree)
```diff
@@            Coverage Diff            @@
##             master      #18   +/-   ##
=========================================
Coverage          ?   31.54%
=========================================
Files             ?       82
Lines             ?     4413
Branches          ?      674
=========================================
Hits              ?     1392
Misses            ?     2795
Partials          ?      226
```
------
[Continue to review full report at Codecov](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18?src=pr&el=continue).
> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)
> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`
> Powered by [Codecov](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18?src=pr&el=footer). Last update [b2f5045...3fea39f](https://codecov.io/gh/javydreamercsw/tournament-manager/pull/18?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).


<a href='https://www.codereviewhub.com/javydreamercsw/tournament-manager/pull/18?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/javydreamercsw/tournament-manager/pull/18?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/javydreamercsw/tournament-manager/pull/18?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/javydreamercsw/tournament-manager/pull/18'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>